### PR TITLE
🤖 Add .meta/config.json file for concepts

### DIFF
--- a/concepts/arrays/.meta/config.json
+++ b/concepts/arrays/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for arrays concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/attributes/.meta/config.json
+++ b/concepts/attributes/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for attributes concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": [
+    "valentin-p"
+  ]
+}

--- a/concepts/basics/.meta/config.json
+++ b/concepts/basics/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for basics concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/bit-manipulation/.meta/config.json
+++ b/concepts/bit-manipulation/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for bit-manipulation concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/booleans/.meta/config.json
+++ b/concepts/booleans/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for booleans concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/casting/.meta/config.json
+++ b/concepts/casting/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for casting concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/chars/.meta/config.json
+++ b/concepts/chars/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for chars concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/classes/.meta/config.json
+++ b/concepts/classes/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for classes concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/compound-assignment/.meta/config.json
+++ b/concepts/compound-assignment/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for compound-assignment concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/const-readonly/.meta/config.json
+++ b/concepts/const-readonly/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for const-readonly concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/constants/.meta/config.json
+++ b/concepts/constants/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for constants concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/constructors/.meta/config.json
+++ b/concepts/constructors/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for constructors concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/datetimes/.meta/config.json
+++ b/concepts/datetimes/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for datetimes concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": [
+    "valentin-p"
+  ]
+}

--- a/concepts/defensive-copying/.meta/config.json
+++ b/concepts/defensive-copying/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for defensive-copying concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/dictionaries/.meta/config.json
+++ b/concepts/dictionaries/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "blurb": "TODO: add blurb for dictionaries concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom",
+    "valentin-p"
+  ]
+}

--- a/concepts/do-while-loops/.meta/config.json
+++ b/concepts/do-while-loops/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for do-while-loops concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/enums/.meta/config.json
+++ b/concepts/enums/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for enums concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": [
+    "valentin-p"
+  ]
+}

--- a/concepts/equality/.meta/config.json
+++ b/concepts/equality/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for equality concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/exception-filtering/.meta/config.json
+++ b/concepts/exception-filtering/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for exception-filtering concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/exceptions/.meta/config.json
+++ b/concepts/exceptions/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for exceptions concept",
+  "authors": [
+    "archrisV"
+  ],
+  "contributors": [
+    "valentin-p"
+  ]
+}

--- a/concepts/explicit-casts/.meta/config.json
+++ b/concepts/explicit-casts/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for explicit-casts concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/expression-bodied-members/.meta/config.json
+++ b/concepts/expression-bodied-members/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for expression-bodied-members concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/flag-enums/.meta/config.json
+++ b/concepts/flag-enums/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for flag-enums concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": [
+    "valentin-p"
+  ]
+}

--- a/concepts/floating-point-numbers/.meta/config.json
+++ b/concepts/floating-point-numbers/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for floating-point-numbers concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/for-loops/.meta/config.json
+++ b/concepts/for-loops/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for for-loops concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/foreach-loops/.meta/config.json
+++ b/concepts/foreach-loops/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for foreach-loops concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/generic-types/.meta/config.json
+++ b/concepts/generic-types/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for generic-types concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/if-statements/.meta/config.json
+++ b/concepts/if-statements/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for if-statements concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/indexers/.meta/config.json
+++ b/concepts/indexers/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for indexers concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/inheritance/.meta/config.json
+++ b/concepts/inheritance/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for inheritance concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/integral-numbers/.meta/config.json
+++ b/concepts/integral-numbers/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for integral-numbers concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/interfaces/.meta/config.json
+++ b/concepts/interfaces/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "blurb": "TODO: add blurb for interfaces concept",
+  "authors": [
+    "senal",
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/lists/.meta/config.json
+++ b/concepts/lists/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for lists concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/memory-allocation/.meta/config.json
+++ b/concepts/memory-allocation/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for memory-allocation concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/method-overloading/.meta/config.json
+++ b/concepts/method-overloading/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for method-overloading concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/named-arguments/.meta/config.json
+++ b/concepts/named-arguments/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for named-arguments concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/namespaces/.meta/config.json
+++ b/concepts/namespaces/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "blurb": "TODO: add blurb for namespaces concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom",
+    "valentin-p"
+  ]
+}

--- a/concepts/nested-types/.meta/config.json
+++ b/concepts/nested-types/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for nested-types concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/nullability/.meta/config.json
+++ b/concepts/nullability/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for nullability concept",
+  "authors": [
+    "maurelio1234"
+  ],
+  "contributors": []
+}

--- a/concepts/numbers/.meta/config.json
+++ b/concepts/numbers/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for numbers concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/object-initializers/.meta/config.json
+++ b/concepts/object-initializers/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for object-initializers concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/operator-overloading/.meta/config.json
+++ b/concepts/operator-overloading/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for operator-overloading concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/optional-parameters/.meta/config.json
+++ b/concepts/optional-parameters/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for optional-parameters concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/ordering/.meta/config.json
+++ b/concepts/ordering/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "blurb": "TODO: add blurb for ordering concept",
+  "authors": [
+    "senal",
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/overflow/.meta/config.json
+++ b/concepts/overflow/.meta/config.json
@@ -1,0 +1,12 @@
+{
+  "blurb": "TODO: add blurb for overflow concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ihid",
+    "sleeplessbyte",
+    "saschamann",
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/parameters/.meta/config.json
+++ b/concepts/parameters/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for parameters concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/properties/.meta/config.json
+++ b/concepts/properties/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for properties concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/randomness/.meta/config.json
+++ b/concepts/randomness/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for randomness concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/readonly-collections/.meta/config.json
+++ b/concepts/readonly-collections/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for readonly-collections concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/regular-expressions/.meta/config.json
+++ b/concepts/regular-expressions/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for regular-expressions concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/resource-cleanup/.meta/config.json
+++ b/concepts/resource-cleanup/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for resource-cleanup concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/resource-lifetime/.meta/config.json
+++ b/concepts/resource-lifetime/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for resource-lifetime concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/sets/.meta/config.json
+++ b/concepts/sets/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for sets concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/string-builder/.meta/config.json
+++ b/concepts/string-builder/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for string-builder concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/string-formatting/.meta/config.json
+++ b/concepts/string-formatting/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for string-formatting concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/string-interpolation/.meta/config.json
+++ b/concepts/string-interpolation/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for string-interpolation concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/strings/.meta/config.json
+++ b/concepts/strings/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for strings concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/concepts/structs/.meta/config.json
+++ b/concepts/structs/.meta/config.json
@@ -1,0 +1,11 @@
+{
+  "blurb": "TODO: add blurb for structs concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "efx",
+    "jrr",
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/switch-expressions/.meta/config.json
+++ b/concepts/switch-expressions/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for switch-expressions concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/switch-statements/.meta/config.json
+++ b/concepts/switch-statements/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "blurb": "TODO: add blurb for switch-statements concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom",
+    "valentin-p"
+  ]
+}

--- a/concepts/ternary-operators/.meta/config.json
+++ b/concepts/ternary-operators/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for ternary-operators concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/throw-expressions/.meta/config.json
+++ b/concepts/throw-expressions/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for throw-expressions concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/time/.meta/config.json
+++ b/concepts/time/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for time concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/timezone/.meta/config.json
+++ b/concepts/timezone/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for timezone concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/tuples/.meta/config.json
+++ b/concepts/tuples/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for tuples concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/user-defined-exceptions/.meta/config.json
+++ b/concepts/user-defined-exceptions/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for user-defined-exceptions concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/varargs/.meta/config.json
+++ b/concepts/varargs/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "TODO: add blurb for varargs concept",
+  "authors": [],
+  "contributors": []
+}

--- a/concepts/verbatim-strings/.meta/config.json
+++ b/concepts/verbatim-strings/.meta/config.json
@@ -1,0 +1,9 @@
+{
+  "blurb": "TODO: add blurb for verbatim-strings concept",
+  "authors": [
+    "mikedamay"
+  ],
+  "contributors": [
+    "ErikSchierboom"
+  ]
+}

--- a/concepts/while-loops/.meta/config.json
+++ b/concepts/while-loops/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "TODO: add blurb for while-loops concept",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": []
+}

--- a/config.json
+++ b/config.json
@@ -15,10 +15,18 @@
     "indent_size": 4
   },
   "files": {
-    "solution": ["%{pascal_slug}.cs"],
-    "test": ["%{pascal_slug}Tests.cs"],
-    "example": [".meta/Example.cs"],
-    "exemplar": [".meta/Exemplar.cs"]
+    "solution": [
+      "%{pascal_slug}.cs"
+    ],
+    "test": [
+      "%{pascal_slug}Tests.cs"
+    ],
+    "example": [
+      ".meta/Example.cs"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.cs"
+    ]
   },
   "exercises": {
     "concept": [
@@ -647,8 +655,14 @@
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "57f02d0e-7b75-473b-892d-26a7d980c4ce",
-        "practices": ["optional-parameters", "string-interpolation"],
-        "prerequisites": ["optional-parameters", "string-interpolation"],
+        "practices": [
+          "optional-parameters",
+          "string-interpolation"
+        ],
+        "prerequisites": [
+          "optional-parameters",
+          "string-interpolation"
+        ],
         "difficulty": 1,
         "topics": [
           "optional_values",
@@ -659,8 +673,15 @@
         "slug": "leap",
         "name": "Leap",
         "uuid": "8ba15933-29a2-49b1-a9ce-70474bad3007",
-        "practices": ["math-operators", "if-statements"],
-        "prerequisites": ["math-operators", "if-statements", "numbers"],
+        "practices": [
+          "math-operators",
+          "if-statements"
+        ],
+        "prerequisites": [
+          "math-operators",
+          "if-statements",
+          "numbers"
+        ],
         "difficulty": 1,
         "topics": [
           "conditionals",
@@ -1106,8 +1127,18 @@
         "slug": "accumulate",
         "name": "Accumulate",
         "uuid": "3c0563dc-665a-45b4-9b29-f133e235efd0",
-        "practices": ["lambdas", "foreach", "yield"],
-        "prerequisites": ["lambdas", "generic-types", "foreach", "enumerables", "extension-methods"],
+        "practices": [
+          "lambdas",
+          "foreach",
+          "yield"
+        ],
+        "prerequisites": [
+          "lambdas",
+          "generic-types",
+          "foreach",
+          "enumerables",
+          "extension-methods"
+        ],
         "difficulty": 2,
         "topics": [
           "extension_methods",
@@ -2209,416 +2240,347 @@
     {
       "uuid": "efc1a32a-ebea-45ab-8c0b-5b512717abc0",
       "slug": "arrays",
-      "name": "Arrays",
-      "blurb": "TODO: add blurb for arrays concept"
+      "name": "Arrays"
     },
     {
       "uuid": "06a39e16-780f-4d44-811e-53ebf2fdf6d5",
       "slug": "attributes",
-      "name": "Attributes",
-      "blurb": "TODO: add blurb for attributes concept"
+      "name": "Attributes"
     },
     {
       "uuid": "2eb4a463-355f-46ef-ac55-a75ec5afdf86",
       "slug": "basics",
-      "name": "Basics",
-      "blurb": "TODO: add blurb for basics concept"
+      "name": "Basics"
     },
     {
       "uuid": "83226d8e-9d8b-4223-82ad-6d251f519a49",
       "slug": "bit-manipulation",
-      "name": "Bit Manipulation",
-      "blurb": "TODO: add blurb for bit-manipulation concept"
+      "name": "Bit Manipulation"
     },
     {
       "uuid": "64a2670d-f61a-419f-8623-7116bad8e8a7",
       "slug": "booleans",
-      "name": "Booleans",
-      "blurb": "TODO: add blurb for booleans concept"
+      "name": "Booleans"
     },
     {
       "uuid": "e3b507b0-d2c3-4791-9c6e-6a40bdb4ec1a",
       "slug": "casting",
-      "name": "Casting",
-      "blurb": "TODO: add blurb for casting concept"
+      "name": "Casting"
     },
     {
       "uuid": "352db7e4-c47c-42cf-a290-74e42fadc6ff",
       "slug": "chars",
-      "name": "Chars",
-      "blurb": "TODO: add blurb for chars concept"
+      "name": "Chars"
     },
     {
       "uuid": "5b2f9bbb-079c-47fd-9ba6-0c6469e547cb",
       "slug": "classes",
-      "name": "Classes",
-      "blurb": "TODO: add blurb for classes concept"
+      "name": "Classes"
     },
     {
       "uuid": "2c1ac74e-cec8-4616-a1c4-a08ef9f3f926",
       "slug": "compound-assignment",
-      "name": "Compound Assignment",
-      "blurb": "TODO: add blurb for compound-assignment concept"
+      "name": "Compound Assignment"
     },
     {
       "uuid": "43820de3-174a-41a3-9fc0-d7a6f0c393aa",
       "slug": "ternary-operators",
-      "name": "Conditionals Ternary",
-      "blurb": "TODO: add blurb for ternary-operators concept"
+      "name": "Conditionals Ternary"
     },
     {
       "uuid": "b29bc90a-65ae-4984-b7de-17debee7fc5f",
       "slug": "const-readonly",
-      "name": "Const Readonly",
-      "blurb": "TODO: add blurb for const-readonly concept"
+      "name": "Const Readonly"
     },
     {
       "uuid": "0ae08bee-1252-4d21-ae47-4952a1ab03b5",
       "slug": "constants",
-      "name": "Constants",
-      "blurb": "TODO: add blurb for constants concept"
+      "name": "Constants"
     },
     {
       "uuid": "250f7606-f01d-4713-8e3e-1b1056a6b790",
       "slug": "constructors",
-      "name": "Constructors",
-      "blurb": "TODO: add blurb for constructors concept"
+      "name": "Constructors"
     },
     {
       "uuid": "bed44bba-b5a5-43e7-a548-b17812a6f536",
       "slug": "datetimes",
-      "name": "Datetimes",
-      "blurb": "TODO: add blurb for datetimes concept"
+      "name": "Datetimes"
     },
     {
       "uuid": "c710b7f8-226f-4cc0-8a8f-b125cebb13fc",
       "slug": "defensive-copying",
-      "name": "Defensive Copying",
-      "blurb": "TODO: add blurb for defensive-copying concept"
+      "name": "Defensive Copying"
     },
     {
       "uuid": "3af88acb-1487-4554-8715-089d7dda1199",
       "slug": "dictionaries",
-      "name": "Dictionaries",
-      "blurb": "TODO: add blurb for dictionaries concept"
+      "name": "Dictionaries"
     },
     {
       "uuid": "5b04ddb3-54ff-479f-a525-fb4f117d5c34",
       "slug": "do-while-loops",
-      "name": "Do While Loops",
-      "blurb": "TODO: add blurb for do-while-loops concept"
+      "name": "Do While Loops"
     },
     {
       "uuid": "d5b628d9-ac64-4eeb-91c7-f2dcff798b31",
       "slug": "enums",
-      "name": "Enums",
-      "blurb": "TODO: add blurb for enums concept"
+      "name": "Enums"
     },
     {
       "uuid": "08632727-cfae-4c5b-b53f-f04ba35ce4ed",
       "slug": "equality",
-      "name": "Equality",
-      "blurb": "TODO: add blurb for equality concept"
+      "name": "Equality"
     },
     {
       "uuid": "d3f5d61c-6bed-46ef-be21-cf7fdc07d4f7",
       "slug": "exception-filtering",
-      "name": "Exception Filtering",
-      "blurb": "TODO: add blurb for exception-filtering concept"
+      "name": "Exception Filtering"
     },
     {
       "uuid": "6a322f90-1428-4ced-ba8c-cdcadf8914bd",
       "slug": "exceptions",
-      "name": "Exceptions",
-      "blurb": "TODO: add blurb for exceptions concept"
+      "name": "Exceptions"
     },
     {
       "uuid": "c82d74c8-fbe1-42ab-be71-b1f524f28bf6",
       "slug": "explicit-casts",
-      "name": "Explicit Casts",
-      "blurb": "TODO: add blurb for explicit-casts concept"
+      "name": "Explicit Casts"
     },
     {
       "uuid": "8e69833b-9668-4ed1-bfdd-d3c90fe4d9a4",
       "slug": "expression-bodied-members",
-      "name": "Expression Bodied Members",
-      "blurb": "TODO: add blurb for expression-bodied-members concept"
+      "name": "Expression Bodied Members"
     },
     {
       "uuid": "0d0ce715-a7f2-42f4-b97b-54ba99b4df73",
       "slug": "flag-enums",
-      "name": "Flag Enums",
-      "blurb": "TODO: add blurb for flag-enums concept"
+      "name": "Flag Enums"
     },
     {
       "uuid": "05cd97a1-fedb-40c1-9f73-3a47d3f8690d",
       "slug": "floating-point-numbers",
-      "name": "Floating Point Numbers",
-      "blurb": "TODO: add blurb for floating-point-numbers concept"
+      "name": "Floating Point Numbers"
     },
     {
       "uuid": "bd406da5-7a16-4487-a820-ce7ef5f1066b",
       "slug": "for-loops",
-      "name": "For Loops",
-      "blurb": "TODO: add blurb for for-loops concept"
+      "name": "For Loops"
     },
     {
       "uuid": "a352e32f-2e90-43ba-94c3-f22dc985e10a",
       "slug": "foreach-loops",
-      "name": "Foreach Loops",
-      "blurb": "TODO: add blurb for foreach-loops concept"
+      "name": "Foreach Loops"
     },
     {
       "uuid": "555dc4c4-b30e-4928-a52e-336b05c26fca",
       "slug": "generic-types",
-      "name": "Generic Types",
-      "blurb": "TODO: add blurb for generic-types concept"
+      "name": "Generic Types"
     },
     {
       "uuid": "4466e33e-dcd2-4b1f-9d9d-2c4315bf5188",
       "slug": "if-statements",
-      "name": "If Statements",
-      "blurb": "TODO: add blurb for if-statements concept"
+      "name": "If Statements"
     },
     {
       "uuid": "760a9811-a77f-4022-bc62-2a84dfbddbfc",
       "slug": "indexers",
-      "name": "Indexers",
-      "blurb": "TODO: add blurb for indexers concept"
+      "name": "Indexers"
     },
     {
       "uuid": "4725bc7b-481a-4ba2-951d-e7fa42c5b0c3",
       "slug": "inheritance",
-      "name": "Inheritance",
-      "blurb": "TODO: add blurb for inheritance concept"
+      "name": "Inheritance"
     },
     {
       "uuid": "0b793025-5434-4c3d-ab72-67578669529f",
       "slug": "integral-numbers",
-      "name": "Integral Numbers",
-      "blurb": "TODO: add blurb for integral-numbers concept"
+      "name": "Integral Numbers"
     },
     {
       "uuid": "10b71949-a188-481a-8c24-04a9c20c1530",
       "slug": "interfaces",
-      "name": "Interfaces",
-      "blurb": "TODO: add blurb for interfaces concept"
+      "name": "Interfaces"
     },
     {
       "uuid": "dd7bf404-59af-4ae6-895b-5d04cdc8ecaa",
       "slug": "lists",
-      "name": "Lists",
-      "blurb": "TODO: add blurb for lists concept"
+      "name": "Lists"
     },
     {
       "uuid": "a93a154c-4706-4c01-8ece-b5504ba3378d",
       "slug": "memory-allocation",
-      "name": "Memory Allocation",
-      "blurb": "TODO: add blurb for memory-allocation concept"
+      "name": "Memory Allocation"
     },
     {
       "uuid": "e4c0bba5-e08b-426a-bccf-0f0fb375c2ad",
       "slug": "method-overloading",
-      "name": "Method Overloading",
-      "blurb": "TODO: add blurb for method-overloading concept"
+      "name": "Method Overloading"
     },
     {
       "uuid": "3b67cb8b-bcd3-4d34-ad4c-8e2009c3e6b5",
       "slug": "named-arguments",
-      "name": "Named Arguments",
-      "blurb": "TODO: add blurb for named-arguments concept"
+      "name": "Named Arguments"
     },
     {
       "uuid": "944d243a-65bc-4a52-97e8-b692a8419d04",
       "slug": "namespaces",
-      "name": "Namespaces",
-      "blurb": "TODO: add blurb for namespaces concept"
+      "name": "Namespaces"
     },
     {
       "uuid": "339dce38-c4b6-423d-9b66-88fed35408d4",
       "slug": "nested-types",
-      "name": "Nested Types",
-      "blurb": "TODO: add blurb for nested-types concept"
+      "name": "Nested Types"
     },
     {
       "uuid": "f66d4f26-ebd8-41d0-b79e-05858491e035",
       "slug": "nullability",
-      "name": "Nullability",
-      "blurb": "TODO: add blurb for nullability concept"
+      "name": "Nullability"
     },
     {
       "uuid": "b9a421b2-c5ff-4213-bd6d-b886da31ea0d",
       "slug": "numbers",
-      "name": "Numbers",
-      "blurb": "TODO: add blurb for numbers concept"
+      "name": "Numbers"
     },
     {
       "uuid": "9b50d5ee-7b68-46e3-9c3b-893c3a83110f",
       "slug": "object-initializers",
-      "name": "Object Initializers",
-      "blurb": "TODO: add blurb for object-initializers concept"
+      "name": "Object Initializers"
     },
     {
       "uuid": "3b510fdc-2975-41e4-acc5-c6b3780acf50",
       "slug": "operator-overloading",
-      "name": "Operator Overloading",
-      "blurb": "TODO: add blurb for operator-overloading concept"
+      "name": "Operator Overloading"
     },
     {
       "uuid": "cddf1b02-6dcd-4ef0-9847-a2cd35abdb80",
       "slug": "optional-parameters",
-      "name": "Optional Parameters",
-      "blurb": "TODO: add blurb for optional-parameters concept"
+      "name": "Optional Parameters"
     },
     {
       "uuid": "9f993d9a-144c-45fe-ab09-e368b5be2e6c",
       "slug": "ordering",
-      "name": "Ordering",
-      "blurb": "TODO: add blurb for ordering concept"
+      "name": "Ordering"
     },
     {
       "uuid": "a9ea7864-bfc7-49ce-815b-32d018627fe9",
       "slug": "overflow",
-      "name": "Overflow",
-      "blurb": "TODO: add blurb for overflow concept"
+      "name": "Overflow"
     },
     {
       "uuid": "83414ea8-0335-485c-a826-95c88a532d65",
       "slug": "parameters",
-      "name": "Parameters",
-      "blurb": "TODO: add blurb for parameters concept"
+      "name": "Parameters"
     },
     {
       "uuid": "7149c281-8b8c-42a2-a534-7bc5553cbbce",
       "slug": "properties",
-      "name": "Properties",
-      "blurb": "TODO: add blurb for properties concept"
+      "name": "Properties"
     },
     {
       "uuid": "b71dc153-1cb0-4b82-ab5f-d896d6f1f7ed",
       "slug": "randomness",
-      "name": "Randomness",
-      "blurb": "TODO: add blurb for randomness concept"
+      "name": "Randomness"
     },
     {
       "uuid": "34e99b87-8862-47a7-87d3-621e1db47e5c",
       "slug": "readonly-collections",
-      "name": "Readonly Collections",
-      "blurb": "TODO: add blurb for readonly-collections concept"
+      "name": "Readonly Collections"
     },
     {
       "uuid": "3c67b33f-e2a6-45e9-b4c4-456044e3c6ef",
       "slug": "regular-expressions",
-      "name": "Regular Expressions",
-      "blurb": "TODO: add blurb for regular-expressions concept"
+      "name": "Regular Expressions"
     },
     {
       "uuid": "726f35e6-8af7-4279-b3bc-5299e1b7c182",
       "slug": "resource-cleanup",
-      "name": "Resource Cleanup",
-      "blurb": "TODO: add blurb for resource-cleanup concept"
+      "name": "Resource Cleanup"
     },
     {
       "uuid": "64ef0e6d-ca7a-4a3e-81a7-e66766615a9b",
       "slug": "resource-lifetime",
-      "name": "Resource Lifetime",
-      "blurb": "TODO: add blurb for resource-lifetime concept"
+      "name": "Resource Lifetime"
     },
     {
       "uuid": "d38a4651-09d2-47e5-8a18-9bcb6f3bfa0b",
       "slug": "sets",
-      "name": "Sets",
-      "blurb": "TODO: add blurb for sets concept"
+      "name": "Sets"
     },
     {
       "uuid": "c1fcce17-0cbb-410e-8281-698606d73690",
       "slug": "string-builder",
-      "name": "String Builder",
-      "blurb": "TODO: add blurb for string-builder concept"
+      "name": "String Builder"
     },
     {
       "uuid": "7262549b-0bb3-4650-af34-e655c6ec59c2",
       "slug": "string-formatting",
-      "name": "String Formatting",
-      "blurb": "TODO: add blurb for string-formatting concept"
+      "name": "String Formatting"
     },
     {
       "uuid": "df01147e-eac9-4df8-be9d-7bd81561a3c5",
       "slug": "string-interpolation",
-      "name": "String Interpolation",
-      "blurb": "TODO: add blurb for string-interpolation concept"
+      "name": "String Interpolation"
     },
     {
       "uuid": "fe39a4ab-e760-4e71-804e-2937ecc52b4d",
       "slug": "strings",
-      "name": "Strings",
-      "blurb": "TODO: add blurb for strings concept"
+      "name": "Strings"
     },
     {
       "uuid": "b9a177bc-b815-4e85-9c0f-b84eb059500d",
       "slug": "structs",
-      "name": "Structs",
-      "blurb": "TODO: add blurb for structs concept"
+      "name": "Structs"
     },
     {
       "uuid": "bc342654-6ebc-46fd-8148-eef2c8477a15",
       "slug": "switch-expressions",
-      "name": "Switch Expressions",
-      "blurb": "TODO: add blurb for switch-expressions concept"
+      "name": "Switch Expressions"
     },
     {
       "uuid": "f57713c2-ddf3-4e71-802b-b24b552db609",
       "slug": "switch-statements",
-      "name": "Switch Statements",
-      "blurb": "TODO: add blurb for switch-statements concept"
+      "name": "Switch Statements"
     },
     {
       "uuid": "58d5caa7-1683-44e0-a62f-1564ac6959ab",
       "slug": "throw-expressions",
-      "name": "Throw Expressions",
-      "blurb": "TODO: add blurb for throw-expressions concept"
+      "name": "Throw Expressions"
     },
     {
       "uuid": "050e789f-d318-41df-b2cc-f386ccf349dc",
       "slug": "time",
-      "name": "Time",
-      "blurb": "TODO: add blurb for time concept"
+      "name": "Time"
     },
     {
       "uuid": "3b83bdcc-de0b-43f7-b8f1-41fa9c656fb1",
       "slug": "timezone",
-      "name": "Timezone",
-      "blurb": "TODO: add blurb for timezone concept"
+      "name": "Timezone"
     },
     {
       "uuid": "86848fc2-c1ef-44ce-b099-86feabbbc7c9",
       "slug": "tuples",
-      "name": "Tuples",
-      "blurb": "TODO: add blurb for tuples concept"
+      "name": "Tuples"
     },
     {
       "uuid": "a625c3c3-7299-4426-99e5-f2c850479a29",
       "slug": "user-defined-exceptions",
-      "name": "User Defined Exceptions",
-      "blurb": "TODO: add blurb for user-defined-exceptions concept"
+      "name": "User Defined Exceptions"
     },
     {
       "uuid": "1f78e26c-14d1-402e-a3cd-c786f8b1eec2",
       "slug": "varargs",
-      "name": "Varargs",
-      "blurb": "TODO: add blurb for varargs concept"
+      "name": "Varargs"
     },
     {
       "uuid": "6d85366c-7767-4d6a-af08-4cee5db801ca",
       "slug": "verbatim-strings",
-      "name": "Verbatim Strings",
-      "blurb": "TODO: add blurb for verbatim-strings concept"
+      "name": "Verbatim Strings"
     },
     {
       "uuid": "5442d5da-f74e-4793-97ee-97ddc09d4942",
       "slug": "while-loops",
-      "name": "While Loops",
-      "blurb": "TODO: add blurb for while-loops concept"
+      "name": "While Loops"
     }
   ],
   "key_features": [


### PR DESCRIPTION
_TL;DR; Add authors/contributors to a new `concepts/<slug>/.meta/config.json` to Concepts in the same way you have for Concept Exercises._

---

To properly attribute authorship/contributorship for an individual concept, each concept will have its own `.meta/config.json` file with `authors` and `contributors` keys like those for concept and practice exercises. We're also moving the concept's blurb from the track's `config.json` to the `.meta/config.json` file, also similar to concept and practice exercises.

See https://github.com/exercism/docs/pull/96/files for the update to the specification.

This PR adds a `.meta/config.json` file for all concepts found in the track's `config.json` file containing:

- A `blurb` key, which value is copied from the `config.json` file and subsequently removed from the `config.json` file
- An `authors` key which value is an empty array  
- A `contributors` key which value is an empty array

## Maintainers TODO list

These are the things you, the maintainers, should do:

- [ ] Add the authors
- [ ] Add the contributors (if any)

**For clarity, authors should be the people who originally created the concept documents on this track. Contributors should be people who have substantially contributed to the concept documents. PRs for typos or multiple-concept PRs do not automatically mean someone should be considered a contributor to that concept. Those non-concept-specific contributions will get recognition through Exercism's reputation system in v3.**

You can either update this PR by pushing a new commit to this PR, or merge this and do a follow-up PR later. The former has the disadvantage that once we've added linting rules to `configlet` for the concept `.meta/config.json` file, the configlet CI check will start failing.

## Tracking

https://github.com/exercism/v3-launch/issues/27
